### PR TITLE
Use gt_MSG_ERROR when lexd is missing to fix docs generation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -212,7 +212,7 @@ gt_CONFIG_FILES
 # PKG_CHECK_MODULES(LEXD, lexd >= 1.1.0)
 AC_PATH_PROG([LEXD], [lexd], [no])
 AS_IF([test "x${LEXD}" == xno],
-        [AC_MSG_ERROR([LexD is missing, please install!])
+        [gt_MSG_ERROR([LexD is missing, please install!])
     ])
 
 ############ END: Language-specific scripts. #############


### PR DESCRIPTION
Claude summary:

####  Summary

Replace AC_MSG_ERROR with gt_MSG_ERROR for the LexD dependency check in the language-specific section of configure.ac

####  Why

  The docs generation workflow (docsygen.yml) runs `configure --disable-configure-errors` to allow building docs without the full set of FST tools installed. This works because all tool checks in the giella infrastructure use gt_MSG_ERROR, which
  respects that flag — when passed, errors become non-fatal notices and configure continues.

  The LexD check in this repo uses AC_MSG_ERROR directly, which is a hard abort that ignores --disable-configure-errors. This causes the docs workflow to fail even though LexD is not needed for documentation generation.

  This change has no effect on normal usage. When --disable-configure-errors is not passed (the default), gt_MSG_ERROR behaves identically to AC_MSG_ERROR — users still get a fatal error telling them to install LexD. The only difference is that
  CI workflows that explicitly opt into error suppression can now proceed.
